### PR TITLE
feat: implement GCS image URL serving for plant images

### DIFF
--- a/app/api/endpoints/plants.py
+++ b/app/api/endpoints/plants.py
@@ -33,3 +33,37 @@ async def get_all_plants(
         return await plant_service.get_all_plants_with_images()
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error loading plants: {str(e)}")
+
+
+@router.get("/plants/{plant_id}/image-url")
+async def get_plant_image_url(
+    plant_id: int,
+    plant_service: PlantService = Depends(get_plant_service)
+):
+    """Get the primary GCS image URL for a specific plant"""
+    try:
+        image_url = await plant_service.get_plant_image_url(plant_id)
+        if not image_url:
+            raise HTTPException(status_code=404, detail="Plant or image not found")
+        return {"image_url": image_url}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error getting image URL: {str(e)}")
+
+
+@router.get("/plants/{plant_id}/all-images")
+async def get_all_plant_images(
+    plant_id: int,
+    plant_service: PlantService = Depends(get_plant_service)
+):
+    """Get all GCS image URLs for a specific plant (usually 2-4 images)"""
+    try:
+        image_urls = await plant_service.get_all_plant_image_urls(plant_id)
+        if not image_urls:
+            raise HTTPException(status_code=404, detail="Plant not found")
+        return {"image_urls": image_urls}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error getting image URLs: {str(e)}")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -60,6 +60,9 @@ class Settings:
     OPEN_METEO_API_KEY: str = os.getenv("OPEN_METEO_API_KEY", "")
     EPA_VIC_API_KEY: str = os.getenv("EPA_VIC_API_KEY", "")
     
+    # Google Cloud Storage
+    GCS_BUCKET_URL: str = os.getenv("GCS_BUCKET_URL", "https://storage.googleapis.com/plantopia-images-1757656642/plant_images")
+
     # Environment
     ENVIRONMENT: str = os.getenv("ENVIRONMENT", "development")
     DEBUG: bool = os.getenv("DEBUG", "False").lower() == "true"

--- a/app/services/plant_service.py
+++ b/app/services/plant_service.py
@@ -1,13 +1,15 @@
 from typing import List, Dict, Any, Optional
+import re
 
 from app.repositories.database_plant_repository import DatabasePlantRepository
 from app.utils.image_utils import image_to_base64
 from app.schemas.response import PlantMedia, AllPlantsResponse
+from app.core.config import settings
 
 
 class PlantService:
     """Service for plant-related operations"""
-    
+
     def __init__(self, plant_repository: DatabasePlantRepository):
         self.plant_repository = plant_repository
     
@@ -61,11 +63,105 @@ class PlantService:
     
     async def get_plants_by_category(self, category: str) -> List[Dict[str, Any]]:
         """Get all plants of a specific category.
-        
+
         Args:
             category: Plant category (flower, herb, vegetable)
-            
+
         Returns:
             List of plants in the category
         """
         return await self.plant_repository.get_plants_by_category(category)
+
+    def generate_gcs_image_urls(self, plant_name: str, plant_category: str, scientific_name: str = None) -> List[str]:
+        """Generate GCS image URLs for a plant.
+
+        Args:
+            plant_name: Name of the plant
+            plant_category: Category of the plant (flower, herb, vegetable)
+            scientific_name: Scientific name of the plant (optional)
+
+        Returns:
+            List of GCS URLs for the plant images
+        """
+        # Map category to folder name
+        category_folder = f"{plant_category.lower()}_plant_images"
+
+        # The folder name format is: "Plant Name_Scientific Name"
+        # If scientific name is not provided or is 'unknown', use just the plant name
+        if scientific_name and scientific_name.lower() != 'unknown':
+            folder_name = f"{plant_name}_{scientific_name}"
+        else:
+            # For cases where scientific name is unknown, try just the plant name
+            folder_name = f"{plant_name}_unknown"
+
+        # Generate URLs for potential multiple images (1-4)
+        base_url = f"{settings.GCS_BUCKET_URL}/{category_folder}/{folder_name}"
+
+        # Most plants have 2-4 images, generate URLs for all possibilities
+        # Frontend can handle 404s for non-existent images
+        image_urls = []
+        for i in range(1, 5):  # Generate URLs for _1.jpg to _4.jpg
+            image_url = f"{base_url}/{folder_name}_{i}.jpg"
+            image_urls.append(image_url)
+
+        return image_urls
+
+    def get_primary_image_url(self, plant_name: str, plant_category: str, scientific_name: str = None) -> str:
+        """Get the primary (first) image URL for a plant.
+
+        Args:
+            plant_name: Name of the plant
+            plant_category: Category of the plant
+            scientific_name: Scientific name of the plant (optional)
+
+        Returns:
+            URL of the first image
+        """
+        urls = self.generate_gcs_image_urls(plant_name, plant_category, scientific_name)
+        return urls[0] if urls else None
+
+    async def get_plant_image_url(self, plant_id: int) -> Optional[str]:
+        """Get the primary GCS image URL for a specific plant by ID.
+
+        Args:
+            plant_id: ID of the plant
+
+        Returns:
+            Primary GCS image URL or None if plant not found
+        """
+        plant = await self.plant_repository.get_plant_by_id(plant_id)
+
+        if not plant:
+            return None
+
+        # If plant already has image_url in database, return it
+        if plant.get("image_url"):
+            return plant["image_url"]
+
+        # Otherwise generate it from plant name and category
+        return self.get_primary_image_url(
+            plant["plant_name"],
+            plant.get("plant_category", "flower"),
+            plant.get("scientific_name")
+        )
+
+    async def get_all_plant_image_urls(self, plant_id: int) -> Optional[List[str]]:
+        """Get all GCS image URLs for a specific plant by ID.
+
+        Args:
+            plant_id: ID of the plant
+
+        Returns:
+            List of all GCS image URLs or None if plant not found
+        """
+        plant = await self.plant_repository.get_plant_by_id(plant_id)
+
+        if not plant:
+            return None
+
+        # Generate all possible image URLs
+        return self.generate_gcs_image_urls(
+            plant["plant_name"],
+            plant.get("plant_category", "flower"),
+            plant.get("scientific_name")
+        )

--- a/scripts/update_image_urls.py
+++ b/scripts/update_image_urls.py
@@ -1,0 +1,130 @@
+"""
+Script to update the image_url field in the database with GCS URLs
+"""
+import asyncio
+import sys
+import os
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.append(str(Path(__file__).parent.parent))
+
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy import select, update
+from app.models.database import Plant
+from app.core.config import settings
+from app.services.plant_service import PlantService
+
+
+async def update_plant_image_urls():
+    """Update all plant records with GCS image URLs"""
+
+    # Create database connection with async PostgreSQL driver
+    # Replace postgresql:// with postgresql+asyncpg:// for async support
+    async_db_url = settings.DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://")
+    engine = create_async_engine(async_db_url)
+    async_session = sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    # Create plant service instance (we just need the URL generation methods)
+    plant_service = PlantService(None)
+
+    async with async_session() as session:
+        try:
+            # Get all plants
+            result = await session.execute(select(Plant))
+            plants = result.scalars().all()
+
+            print(f"Found {len(plants)} plants to update")
+
+            updated_count = 0
+            for plant in plants:
+                # Generate the primary image URL
+                image_url = plant_service.get_primary_image_url(
+                    plant.plant_name,
+                    plant.plant_category or "flower",
+                    plant.scientific_name
+                )
+
+                if image_url:
+                    # Update the plant record
+                    plant.image_url = image_url
+                    updated_count += 1
+                    print(f"Updated {plant.plant_name}: {image_url}")
+                else:
+                    print(f"Could not generate URL for {plant.plant_name}")
+
+            # Commit all changes
+            await session.commit()
+            print(f"\nSuccessfully updated {updated_count} plant records with image URLs")
+
+        except Exception as e:
+            print(f"Error updating image URLs: {e}")
+            await session.rollback()
+            raise
+        finally:
+            await engine.dispose()
+
+
+async def verify_image_urls():
+    """Verify that image URLs were updated correctly"""
+
+    # Use async PostgreSQL driver
+    async_db_url = settings.DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://")
+    engine = create_async_engine(async_db_url)
+    async_session = sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    async with async_session() as session:
+        try:
+            # Count plants with and without image URLs
+            result = await session.execute(
+                select(Plant).where(Plant.image_url != None)
+            )
+            plants_with_urls = len(result.scalars().all())
+
+            result = await session.execute(
+                select(Plant).where(Plant.image_url == None)
+            )
+            plants_without_urls = len(result.scalars().all())
+
+            print(f"\nVerification Results:")
+            print(f"Plants with image URLs: {plants_with_urls}")
+            print(f"Plants without image URLs: {plants_without_urls}")
+
+            # Show a few sample URLs
+            result = await session.execute(
+                select(Plant).where(Plant.image_url != None).limit(5)
+            )
+            sample_plants = result.scalars().all()
+
+            print(f"\nSample image URLs:")
+            for plant in sample_plants:
+                print(f"  {plant.plant_name}: {plant.image_url}")
+
+        except Exception as e:
+            print(f"Error verifying image URLs: {e}")
+        finally:
+            await engine.dispose()
+
+
+def main():
+    """Main function to run the migration"""
+    print("Starting image URL migration...")
+    print(f"GCS Bucket URL: {settings.GCS_BUCKET_URL}")
+    print("-" * 50)
+
+    # Run the update
+    asyncio.run(update_plant_image_urls())
+
+    # Verify the results
+    asyncio.run(verify_image_urls())
+
+    print("\nMigration complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_image_urls.py
+++ b/tests/unit/test_image_urls.py
@@ -1,0 +1,99 @@
+"""
+Test script to verify GCS image URL generation
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.append(str(Path(__file__).parent))
+
+from app.services.plant_service import PlantService
+from app.core.config import settings
+
+
+def test_image_url_generation():
+    """Test generating GCS image URLs"""
+
+    # Create a plant service instance (no db needed for URL generation)
+    plant_service = PlantService(None)
+
+    print(f"GCS Bucket URL: {settings.GCS_BUCKET_URL}")
+    print("-" * 50)
+
+    # Test cases matching the actual GCS structure
+    test_plants = [
+        ("Alyssum- Royal Carpet", "flower", "Lobularia maritima"),
+        ("Basil- Cinnamon", "herb", "Ocimum basilicum"),
+        ("Basil- Bush", "herb", "unknown"),
+        ("Agave- Foxtail", "flower", "Agave attentuata"),
+    ]
+
+    for plant_name, category, scientific_name in test_plants:
+        print(f"\nPlant: {plant_name}")
+        print(f"Category: {category}")
+        print(f"Scientific Name: {scientific_name}")
+
+        # Get primary image URL
+        primary_url = plant_service.get_primary_image_url(plant_name, category, scientific_name)
+        print(f"Primary Image URL: {primary_url}")
+
+        # Get all image URLs
+        all_urls = plant_service.generate_gcs_image_urls(plant_name, category, scientific_name)
+        print(f"All Image URLs ({len(all_urls)}):")
+        for i, url in enumerate(all_urls, 1):
+            print(f"  Image {i}: {url}")
+
+
+async def test_api_endpoints():
+    """Test the API endpoints (requires running server)"""
+    try:
+        import httpx
+
+        base_url = "http://localhost:8000/api/v1"
+
+        async with httpx.AsyncClient() as client:
+            # Test getting a plant's image URL (assuming plant ID 1 exists)
+            response = await client.get(f"{base_url}/plants/1/image-url")
+            if response.status_code == 200:
+                print("\nAPI Test - Single Image URL:")
+                print(response.json())
+            else:
+                print(f"Error: {response.status_code} - {response.text}")
+
+            # Test getting all image URLs
+            response = await client.get(f"{base_url}/plants/1/all-images")
+            if response.status_code == 200:
+                print("\nAPI Test - All Image URLs:")
+                print(response.json())
+            else:
+                print(f"Error: {response.status_code} - {response.text}")
+
+    except Exception as e:
+        print(f"\nAPI test failed (is the server running?): {e}")
+
+
+def main():
+    """Main test function"""
+    print("=" * 60)
+    print("Testing GCS Image URL Generation")
+    print("=" * 60)
+
+    # Test URL generation
+    test_image_url_generation()
+
+    # Optionally test API endpoints
+    print("\n" + "=" * 60)
+    print("Testing API Endpoints")
+    print("=" * 60)
+    print("\nNote: Start the backend server first for API tests")
+    user_input = input("Test API endpoints? (y/n): ")
+
+    if user_input.lower() == 'y':
+        asyncio.run(test_api_endpoints())
+
+    print("\nTest complete!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
  - Add GCS bucket configuration to serve 2GB of plant images directly
  - Create new API endpoints for fetching plant image URLs
  - Replace inefficient base64 image encoding with direct GCS URLs
  - Add database migration script to populate image_url fields
  - Update recommendation service to return GCS URLs instead of base64