### PR TITLE
Update recommendation limits: default 6, max 9 plants

### DIFF
--- a/app/schemas/request.py
+++ b/app/schemas/request.py
@@ -55,7 +55,7 @@ class UserRequest(BaseModel):
 class RecommendationRequest(BaseModel):
     """Request for plant recommendations"""
     suburb: str = Field(default="Richmond", description="Suburb for climate data")
-    n: int = Field(default=5, ge=1, le=20, description="Number of recommendations")
+    n: int = Field(default=6, ge=1, le=9, description="Number of recommendations")
     climate_zone: Optional[str] = Field(default=None, description="Override climate zone")
     user_preferences: UserRequest = Field(..., description="User preferences")
 


### PR DESCRIPTION
## Summary
- Update default recommendation count from 5 to 6 plants
- Change maximum recommendation limit from 20 to 9 plants  
- Maintain minimum of 1 recommendation per request

## Changes
- Modified `RecommendationRequest` schema in `app/schemas/request.py`
- Updated field validation: `Field(default=6, ge=1, le=9)`

## Test plan
- [ ] Verify API accepts requests with n=1 to n=9
- [ ] Confirm default behavior returns 6 recommendations when n is not specified
- [ ] Test that requests with n>9 are rejected with validation error
- [ ] Check existing recommendation functionality remains intact